### PR TITLE
Timestamps are milliseconds since Unix epoch

### DIFF
--- a/mds/api/client.py
+++ b/mds/api/client.py
@@ -26,7 +26,7 @@ class ProviderClient(OAuthClientCredentialsAuth):
             - git tag
         """
         self.providers = providers if providers is not None else get_registry(ref)
-        self.encoder = CustomJsonEncoder()
+        self.encoder = CustomJsonEncoder(date_format="unix")
 
     def _auth_session(self, provider):
         """

--- a/mds/api/client.py
+++ b/mds/api/client.py
@@ -7,6 +7,7 @@ import json
 import mds
 import time
 from mds.api.auth import OAuthClientCredentialsAuth
+from mds.json import CustomJsonEncoder
 from mds.providers import get_registry, Provider
 
 
@@ -26,6 +27,7 @@ class ProviderClient(OAuthClientCredentialsAuth):
             - git tag
         """
         self.providers = providers if providers is not None else get_registry(ref)
+        self.encoder = CustomJsonEncoder()
 
     def _auth_session(self, provider):
         """
@@ -133,7 +135,7 @@ class ProviderClient(OAuthClientCredentialsAuth):
         """
         Internal helper to format datetimes for querystrings.
         """
-        return int(dt.timestamp()) if isinstance(dt, datetime) else int(dt)
+        return self.encoder.encode(dt) if isinstance(dt, datetime) else int(dt)
 
     def get_status_changes(
         self,

--- a/mds/api/client.py
+++ b/mds/api/client.py
@@ -3,9 +3,8 @@ MDS Provider API client implementation.
 """
 
 from datetime import datetime
-import json
-import mds
 import time
+import mds
 from mds.api.auth import OAuthClientCredentialsAuth
 from mds.json import CustomJsonEncoder
 from mds.providers import get_registry, Provider
@@ -154,10 +153,10 @@ class ProviderClient(OAuthClientCredentialsAuth):
                     The default is to issue the request to all Providers.
 
         :start_time: Filters for status changes where `event_time` occurs at or after the given time
-                     Should be a datetime object or numeric representation of UNIX seconds
+                     Should be a datetime object or int UNIX milliseconds
 
         :end_time: Filters for status changes where `event_time` occurs before the given time
-                   Should be a datetime object or numeric representation of UNIX seconds
+                   Should be a datetime object or int UNIX milliseconds
 
         :paging: True (default) to follow paging and request all available data.
                  False to request only the first page.
@@ -207,10 +206,10 @@ class ProviderClient(OAuthClientCredentialsAuth):
         :vehicle_id: Filters for trips taken by the given vehicle.
 
         :min_end_time: Filters for trips where `end_time` occurs at or after the given time.
-                       Should be a datetime object or numeric representation of UNIX seconds
+                       Should be a datetime object or int UNIX milliseconds
 
         :max_end_time: Filters for trips where `end_time` occurs before the given time.
-                       Should be a datetime object or numeric representation of UNIX seconds
+                       Should be a datetime object or int UNIX milliseconds
 
         :paging: True (default) to follow paging and request all available data.
                  False to request only the first page.

--- a/mds/db/sql.py
+++ b/mds/db/sql.py
@@ -45,7 +45,7 @@ def insert_status_changes_from(source_table, dest_table=mds.STATUS_CHANGES, on_c
         cast(propulsion_type as propulsion_types[]),
         cast(event_type as event_types),
         cast(event_type_reason as event_type_reasons),
-        to_timestamp(event_time) at time zone 'UTC',
+        to_timestamp(cast(event_time as double precision) / 1000) at time zone 'UTC',
         cast(event_location as jsonb),
         battery_pct,
         cast(associated_trips as uuid[])
@@ -102,8 +102,8 @@ def insert_trips_from(source_table, dest_table=mds.TRIPS, on_conflict_update=Fal
         trip_distance,
         cast(route as jsonb),
         accuracy,
-        to_timestamp(start_time) at time zone 'UTC',
-        to_timestamp(end_time) at time zone 'UTC',
+        to_timestamp(cast(start_time as double precision) / 1000) at time zone 'UTC',
+        to_timestamp(cast(end_time as double precision) / 1000) at time zone 'UTC',
         parking_verification_url,
         standard_cost,
         actual_cost

--- a/mds/fake/data.py
+++ b/mds/fake/data.py
@@ -32,7 +32,5 @@ def random_string(k, chars=None):
     return "".join(random.choices(chars, k=k))
 
 def random_file_url(company):
-    return "https://{}.co/{}.jpg".format(
-        "-".join(company.split()), random_string(7)
-    ).lower()
-
+    url = "-".join(company.split())
+    return f"https://{url}.co/{random_string(7)}.jpg".lower()

--- a/mds/json.py
+++ b/mds/json.py
@@ -95,29 +95,33 @@ def read_data_file(src, record_type):
 class CustomJsonEncoder(json.JSONEncoder):
     """
     Provides json encoding for some special types:
-        - datetime -> date_format or string
-        - Point/Polygon -> GeoJSON Feature
-        - tuple -> list
-        - UUID -> str
+
+        - datetime to date_format or str
+        - Point/Polygon to GeoJSON Feature
+        - tuple to list
+        - UUID to str
     """
 
     def __init__(self, *args, **kwargs):
         """
-        Initialize a `CustomJsonEncoder` with an optional :date_format:
-           - `unix` to format dates as Unix timestamps
-           - `iso8601` to format dates as ISO 8601 strings
-           - `<python format string>` for custom formats
+        Initialize a new `CustomJsonEncoder`.
+
+        Optional keyword arguments:
+
+        :date_format: Configure how dates are formatted using one of:
+
+            - unix: format dates as integer milliseconds since Unix epoch (MDS default)
+            - iso8601: format dates as ISO 8601 strings
+            - python format string: custom format
         """
-        if "date_format" in kwargs:
-            self.date_format = kwargs["date_format"]
-            del kwargs["date_format"]
+        self.date_format = kwargs.pop("date_format", "unix")
 
         json.JSONEncoder.__init__(self, *args, **kwargs)
 
     def default(self, obj):
         if isinstance(obj, datetime):
             if self.date_format == "unix":
-                return obj.timestamp()
+                return int(round(obj.timestamp() * 1000))
             elif self.date_format == "iso8601":
                 return obj.isoformat()
             elif self.date_format is not None:


### PR DESCRIPTION
  - tweak our encoder's format for dates

    * converts datetime -> Unix milliseconds when `unix` is the date_format requested
    * `unix` is the default date_format

  - use our encoder to encode datetimes for API querystrings

  - convert incoming milliseconds to a UTC timestamp in Postgres