### PR TITLE
Provider client iterator

### DIFF
--- a/mds/api/__init__.py
+++ b/mds/api/__init__.py
@@ -2,5 +2,4 @@
 Module implementing the MDS Provider API.
 """
 
-from mds.api.client import ProviderClient
-
+from mds.api.client import MultipleProviderClient

--- a/mds/api/client.py
+++ b/mds/api/client.py
@@ -82,7 +82,7 @@ class ProviderClientBase(OAuthClientCredentialsAuth):
         }
 
 
-class SingleProviderClient(ProviderClientBase):
+class ProviderClient(ProviderClientBase):
     def __init__(self, provider):
         self.provider = provider
 
@@ -147,13 +147,13 @@ class SingleProviderClient(ProviderClientBase):
                     break
 
 
-class ProviderClient(ProviderClientBase):
+class MultipleProviderClient(ProviderClientBase):
     """
     Client for MDS Provider APIs
     """
     def __init__(self, providers=None, ref=None):
         """
-        Initialize a new ProviderClient object.
+        Initialize a new MultipleProviderClient object.
 
         :providers: is a list of Providers this client tracks by default. If None is given, downloads and uses the official Provider registry.
 
@@ -164,7 +164,7 @@ class ProviderClient(ProviderClientBase):
         """
         self.providers = providers if providers is not None else get_registry(ref)
 
-    def _request(self, providers, endpoint, params, paging):
+    def _request_from_providers(self, providers, endpoint, params, paging):
         """
         Internal helper for sending requests.
 
@@ -184,7 +184,7 @@ class ProviderClient(ProviderClientBase):
 
         results = {}
         for provider in providers:
-            client = SingleProviderClient(provider)
+            client = ProviderClient(provider)
             try:
                 results[provider] = list(client.request(endpoint, params, paging))
             except requests.RequestException as exc:
@@ -228,7 +228,7 @@ class ProviderClient(ProviderClientBase):
         params = self._prepare_status_changes_params(**kwargs)
 
         # make the request(s)
-        status_changes = self._request(providers, mds.STATUS_CHANGES, params, paging)
+        status_changes = self._request_from_providers(providers, mds.STATUS_CHANGES, params, paging)
 
         return status_changes
 
@@ -272,6 +272,6 @@ class ProviderClient(ProviderClientBase):
         params = self._prepare_trips_params(**kwargs)
 
         # make the request(s)
-        trips = self._request(providers, mds.TRIPS, params, paging)
+        trips = self._request_from_providers(providers, mds.TRIPS, params, paging)
 
         return trips

--- a/mds/api/client.py
+++ b/mds/api/client.py
@@ -1,5 +1,5 @@
 """
-MDS Provider API client implementation. 
+MDS Provider API client implementation.
 """
 
 from datetime import datetime
@@ -155,7 +155,7 @@ class ProviderClient(OAuthClientCredentialsAuth):
                           Should be a datetime object or numeric representation of UNIX seconds
 
             - `bbox`: Filters for status changes where `event_location` is within defined bounding-box.
-                      The order is defined as: southwest longitude, southwest latitude, 
+                      The order is defined as: southwest longitude, southwest latitude,
                       northeast longitude, northeast latitude (separated by commas).
 
                       e.g.
@@ -214,7 +214,7 @@ class ProviderClient(OAuthClientCredentialsAuth):
                           Should be a datetime object or numeric representation of UNIX seconds
 
             - `bbox`: Filters for trips where and point within `route` is within defined bounding-box.
-                      The order is defined as: southwest longitude, southwest latitude, 
+                      The order is defined as: southwest longitude, southwest latitude,
                       northeast longitude, northeast latitude (separated by commas).
 
                       e.g.
@@ -234,7 +234,7 @@ class ProviderClient(OAuthClientCredentialsAuth):
             end_time = self._date_format(end_time)
 
         # gather all the params togethers
-        params = { 
+        params = {
             **dict(device_id=device_id, vehicle_id=vehicle_id, start_time=start_time, end_time=end_time, bbox=bbox),
             **kwargs
         }

--- a/mds/fake/server.py
+++ b/mds/fake/server.py
@@ -1,0 +1,94 @@
+
+from flask import Flask, request, jsonify, url_for
+import json, base64
+
+class PaginationCursor(object):
+    def __init__(self, serialized_cursor=None, offset=None):
+        if offset is not None and serialized_cursor is not None:
+            raise RuntimeError('Cannot initialize with non-None offset AND non-None cursor')
+
+        if serialized_cursor is not None:
+            data = json.loads(base64.b64decode(serialized_cursor).decode('utf-8'))
+            self.offset = data['o']
+        else:
+            self.offset = 0 if offset is None else offset
+
+    def serialize(self):
+        return base64.b64encode(json.dumps({ 'o': self.offset }).encode('utf-8'))
+
+class InMemoryPaginator(object):
+    def __init__(self, all_items, serialized_cursor=None, page_size=20):
+        self.items = all_items
+        self.cursor = PaginationCursor(serialized_cursor)
+        self.page_size = page_size
+
+    def next_cursor_serialized(self):
+        offset = self.cursor.offset
+        return PaginationCursor(offset=offset+self.page_size).serialize()
+
+    def get_page(self):
+        offset = self.cursor.offset
+        return self.items[offset:offset+self.page_size]
+
+def make_mds_response_data(version, resource_name, paginator, **params):
+    return {
+        'version': version,
+        'links': {
+            'next': url_for(resource_name,
+                            cursor=paginator.next_cursor_serialized(),
+                            _external=True,
+                            **params),
+        },
+        'data': {
+            resource_name: paginator.get_page(),
+        }
+    }
+
+def params_match_trip(params, trip):
+    vehicle_id = params.get('vehicle_id')
+    if vehicle_id and trip['vehicle_id'] != vehicle_id:
+        return False
+
+    return True
+
+def params_match_status_change(params, sc):
+    return True
+
+def make_static_server_app(trips=[],
+                           status_changes=[],
+                           version='0.2.0',
+                           page_size=20):
+    app = Flask('mds_static')
+    store = {
+        'trips': trips,
+        'status_changes': status_changes,
+    }
+
+    @app.route('/trips')
+    def trips():
+        params = {
+            'vehicle_id': request.args.get('vehicle_id'),
+            # TODO: support other params
+        }
+        selected_trips = [t for t in store['trips'] if params_match_trip(params, t)]
+        paginator = InMemoryPaginator(selected_trips,
+                                      serialized_cursor=request.args.get('cursor'),
+                                      page_size=page_size)
+        return jsonify(make_mds_response_data(
+            version, 'trips', paginator, **params
+        ))
+
+    @app.route('/status_changes')
+    def status_changes():
+        params = {
+            # TODO
+        }
+        selected_items = [sc for sc in store['status_changes'] if params_match_status_change(params, sc)]
+        paginator = InMemoryPaginator(selected_items,
+                                      serialized_cursor=request.args.get('cursor'),
+                                      page_size=page_size)
+        return jsonify(make_mds_response_data(
+            version, 'status_changes', paginator, **params
+        ))
+
+    return app

--- a/mds/tests/__init__.py
+++ b/mds/tests/__init__.py
@@ -1,0 +1,3 @@
+import unittest
+if __name__ == '__main__':
+    unittest.main()

--- a/mds/tests/__init__.py
+++ b/mds/tests/__init__.py
@@ -1,3 +1,1 @@
-import unittest
-if __name__ == '__main__':
-    unittest.main()
+

--- a/mds/tests/test_api.py
+++ b/mds/tests/test_api.py
@@ -5,7 +5,7 @@ from urllib3.util import parse_url
 
 from mds.fake.server import make_static_server_app
 from mds.providers import Provider
-from mds.api import ProviderClient
+from mds.api import MultipleProviderClient
 
 
 def requests_mock_with_app(app, netloc='testserver'):
@@ -53,7 +53,7 @@ class APITest(unittest.TestCase):
 
     def _all_items_from_app(self, app, endpoint='trips', get_method_kwargs={}):
         with mock_provider(app) as provider:
-            client = ProviderClient(providers=[provider])
+            client = MultipleProviderClient(providers=[provider])
             method = getattr(client, f'get_{endpoint}')
             pages_by_provider = method(**get_method_kwargs)
 

--- a/mds/tests/test_api.py
+++ b/mds/tests/test_api.py
@@ -1,0 +1,78 @@
+import unittest, re, uuid
+from contextlib import contextmanager
+import requests_mock
+from urllib3.util import parse_url
+
+from mds.fake.server import make_static_server_app
+from mds.providers import Provider
+from mds.api import ProviderClient
+
+
+def requests_mock_with_app(app, netloc='testserver'):
+    client = app.test_client()
+    def get_app_response(request, response_context):
+        url_object = parse_url(request.url)
+        app_response = client.get(url_object.request_uri, base_url='https://testserver/')
+        response_context.status_code = app_response.status_code
+        response_context.headers = app_response.headers
+        return app_response.data
+
+    mock = requests_mock.Mocker()
+    matcher = re.compile(f'^https://{netloc}/')
+    mock.register_uri('GET', matcher, content=get_app_response)
+    return mock
+
+@contextmanager
+def mock_provider(app):
+    with requests_mock_with_app(app, netloc='testserver') as mock:
+        provider = Provider(
+            'test',
+            uuid.uuid4(),
+            url='',
+            auth_type='Bearer',
+            token='', # enable simple token auth
+            mds_api_url='https://testserver')
+        yield provider
+
+
+class APITest(unittest.TestCase):
+    def setUp(self):
+        self.empty_app = make_static_server_app(
+            trips=[],
+            status_changes=[],
+            version='0.2.0',
+            page_size=20,
+        )
+
+        self.bogus_data_app = make_static_server_app(
+            trips=list(range(100)),
+            status_changes=list(range(100)),
+            version='0.2.0',
+            page_size=20,
+        )
+
+    def _all_items_from_app(self, app, endpoint='trips', get_method_kwargs={}):
+        with mock_provider(app) as provider:
+            client = ProviderClient(providers=[provider])
+            method = getattr(client, f'get_{endpoint}')
+            pages_by_provider = method(**get_method_kwargs)
+
+            items = []
+            for page in pages_by_provider[provider]:
+                for item in page['data'][endpoint]:
+                    items.append(item)
+            return items
+
+    def test_single_provider(self):
+        # empty provider should return zero trips
+        trips = self._all_items_from_app(self.empty_app, 'trips')
+        self.assertEqual(len(trips), 0)
+
+        # 100-trip provider should return all trips
+        trips = self._all_items_from_app(self.bogus_data_app, 'trips')
+
+        # Turn off paging; should get just first 20 trips
+        self.assertEqual(len(trips), 100)
+        trips = self._all_items_from_app(self.bogus_data_app, 'trips',
+                                         get_method_kwargs=dict(paging=False))
+        self.assertEqual(len(trips), 20)

--- a/mds/tests/test_api.py
+++ b/mds/tests/test_api.py
@@ -63,16 +63,17 @@ class APITest(unittest.TestCase):
                     items.append(item)
             return items
 
-    def test_single_provider(self):
+    def test_single_provider_paging_enabled(self):
         # empty provider should return zero trips
         trips = self._all_items_from_app(self.empty_app, 'trips')
         self.assertEqual(len(trips), 0)
 
         # 100-trip provider should return all trips
         trips = self._all_items_from_app(self.bogus_data_app, 'trips')
-
-        # Turn off paging; should get just first 20 trips
         self.assertEqual(len(trips), 100)
+
+    def test_single_provider_disable_paging(self):
+        # Turn off paging; should get just first 20 trips
         trips = self._all_items_from_app(self.bogus_data_app, 'trips',
                                          get_method_kwargs=dict(paging=False))
         self.assertEqual(len(trips), 20)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+
+Fiona
+geopandas
+jsonschema >= 3.0.0a2
+numpy
+pandas
+psycopg2-binary
+requests
+scipy
+Shapely
+sqlalchemy
+
+flask
+urllib3
+requests
+requests_mock
+ipdb


### PR DESCRIPTION
Rebased on #45 

Refactor provider client to allow consumers to iterate through pages, rather than waiting for all pages before continuing.

Seeks to maintain `ProviderClient` interface without substantive change.