### PR TITLE
Keep the fake MDS data generator's trip endpoints inside the boundary

### DIFF
--- a/mds/db/load.py
+++ b/mds/db/load.py
@@ -102,6 +102,11 @@ class ProviderDataLoader():
                 if query is not None:
                     conn.execute(query)
 
+            # Delete the tmptable  since we did fake tmp tables
+            # and not using Postgres TEMPORARY 
+            conn.execute(f"DROP TABLE {temp}")
+
+
     def load_from_file(self, src, record_type, table, before_load=None, stage_first=True):
         """
         Load the data file of type :record_type: at :src: in the table :table: using the connection

--- a/mds/db/load.py
+++ b/mds/db/load.py
@@ -29,8 +29,8 @@ def data_engine(uri=None, **kwargs):
         backend = kwargs["backend"] if "backend" in kwargs else "postgresql"
         user, password, host, port, db = kwargs["user"], kwargs["password"], kwargs["host"], kwargs["port"], kwargs["db"]
         uri = f"{backend}://{user}:{password}@{host}:{port}/{db}"
-    else:
-        raise KeyError()
+    elif uri is None:
+        raise KeyError("Provide either `uri` or `user`, `password`, `host`, `port`, and `db`.")
 
     return sqlalchemy.create_engine(uri)
 

--- a/mds/db/load.py
+++ b/mds/db/load.py
@@ -102,9 +102,9 @@ class ProviderDataLoader():
                 if query is not None:
                     conn.execute(query)
 
-            # Delete the tmptable  since we did fake tmp tables
-            # and not using Postgres TEMPORARY 
-            conn.execute(f"DROP TABLE {temp}")
+                # Delete the tmptable  since we did fake tmp tables
+                # and not using Postgres TEMPORARY 
+                conn.execute(f"DROP TABLE {temp}")
 
 
     def load_from_file(self, src, record_type, table, before_load=None, stage_first=True):

--- a/mds/fake/geometry.py
+++ b/mds/fake/geometry.py
@@ -7,8 +7,6 @@ import random
 from shapely.geometry import Point
 import shapely.ops
 
-class GeometryError(Exception):
-    pass
 
 def point_within(boundary):
     """
@@ -69,7 +67,7 @@ def point_nearby(point, dist, bearing=None, boundary=None):
         # from our starting point within the boundary; or maybe we were just unlucky.
         # Shrink the distance to the endpoint until we find one inside the boundary.
         if not boundary.contains(point):
-            raise GeometryError(f"Cannot find point nearby the starting point {point}, which is outside the given boundary.")
+            raise ValueError(f"Cannot find point nearby the starting point {point}, which is outside the given boundary.")
 
         while not boundary.contains(end_point):
             dist = dist * 0.9

--- a/mds/fake/geometry.py
+++ b/mds/fake/geometry.py
@@ -7,6 +7,8 @@ import random
 from shapely.geometry import Point
 import shapely.ops
 
+class GeometryError(Exception):
+    pass
 
 def point_within(boundary):
     """
@@ -27,52 +29,51 @@ def point_within(boundary):
 
     return point
 
-def point_nearby(point, dist, bearing=None):
+def point_nearby(point, dist, bearing=None, boundary=None):
     """
     Create a random point :dist: meters from :point:
 
     Uses the Haversine formula to compute a new lat/lon given a distance and
     bearing. Uses the provided bearing, or random if None.
+    If boundary is provided, the returned point will lie within that boundary.
+    If it proves difficult to find a point at the specified distance within the
+    boundary, the returned point may lie less than :dist: meters from :point:.
 
     See: http://www.movable-type.co.uk/scripts/latlong.html#destPoint
     """
-    lat1 = math.radians(point.y)
-    lon1 = math.radians(point.x)
-    ang_dist = dist / 6378100 # radius of Earth in meters
-    bearing = random.uniform(0, 2*math.pi) if bearing is None else bearing
+    if boundary is None:
+        lat1 = math.radians(point.y)
+        lon1 = math.radians(point.x)
+        ang_dist = dist / 6378100 # radius of Earth in meters
+        bearing = random.uniform(0, 2*math.pi) if bearing is None else bearing
 
-    # calc the new latitude
-    lat2 = math.asin(math.sin(lat1) * math.cos(ang_dist) + 
-                     math.cos(lat1) * math.sin(ang_dist) * math.cos(bearing))
+        # calc the new latitude
+        lat2 = math.asin(math.sin(lat1) * math.cos(ang_dist) +
+                        math.cos(lat1) * math.sin(ang_dist) * math.cos(bearing))
 
-    # calc the new longitude
-    lon2 = lon1 + math.atan2(math.sin(bearing) * math.sin(ang_dist) * math.cos(lat1),
-                             math.cos(ang_dist) - math.sin(lat1) * math.sin(lat2))
+        # calc the new longitude
+        lon2 = lon1 + math.atan2(math.sin(bearing) * math.sin(ang_dist) * math.cos(lat1),
+                                math.cos(ang_dist) - math.sin(lat1) * math.sin(lat2))
 
-    # return the new point
-    return Point(math.degrees(lon2), math.degrees(lat2))
+        # return the new point
+        return Point(math.degrees(lon2), math.degrees(lat2))
+    else:
+        MAX_TRIES = 50 if bearing is None else 1
 
-def point_nearby_within(start_point, dist, boundary):
-    """
-    Create a random point :dist: meters from :start_point: within :boundary:.
+        for _ in range(MAX_TRIES):
+            end_point = point_nearby(point, dist, bearing)
+            if boundary.contains(end_point):
+                return end_point
 
-    If it proves hard to find such a point, return a point within :boundary:
-    that is not more than :dist: meters from :start_point:
-
-    Prerequisites: start_point must itself be within the boundary
-    """
-    MAX_TRIES = 50
-
-    for _ in range(MAX_TRIES):
-        end_point = point_nearby(start_point, dist)
-        if boundary.contains(end_point):
-            return end_point
-
-    # If we got here it's possible there was no point at that exact distance
-    # from our starting point within the boundary; or maybe we were just unlucky.
-    # Shrink the distance to the endpoint until we find one inside the boundary.
-    assert(boundary.contains(start_point))
-    while not boundary.contains(end_point):
-        dist = dist * 0.9
-        end_point = point_nearby(start_point, dist)
-    return end_point
+        # If we got here it's possible there was no point at that exact distance and bearing
+        # from our starting point within the boundary; or maybe we were just unlucky.
+        # Shrink the distance to the endpoint until we find one inside the boundary.
+        if not boundary.contains(point):
+            raise GeometryError(
+                'point_nearby called with a starting point {} outside the given boundary.'
+                'Aborting because in that case it is not guaranteed to terminate.'.format(point))
+        assert(boundary.contains(point))
+        while not boundary.contains(end_point):
+            dist = dist * 0.9
+            end_point = point_nearby(point, dist, bearing)
+        return end_point

--- a/mds/fake/geometry.py
+++ b/mds/fake/geometry.py
@@ -69,11 +69,10 @@ def point_nearby(point, dist, bearing=None, boundary=None):
         # from our starting point within the boundary; or maybe we were just unlucky.
         # Shrink the distance to the endpoint until we find one inside the boundary.
         if not boundary.contains(point):
-            raise GeometryError(
-                'point_nearby called with a starting point {} outside the given boundary.'
-                'Aborting because in that case it is not guaranteed to terminate.'.format(point))
-        assert(boundary.contains(point))
+            raise GeometryError(f"Cannot find point nearby the starting point {point}, which is outside the given boundary.")
+
         while not boundary.contains(end_point):
             dist = dist * 0.9
             end_point = point_nearby(point, dist, bearing)
+
         return end_point

--- a/mds/fake/provider.py
+++ b/mds/fake/provider.py
@@ -7,7 +7,7 @@ import math
 import mds
 from mds.json import extract_point, to_feature
 from mds.fake.data import random_date_from, random_string, random_file_url
-from mds.fake.geometry import point_within, point_nearby_within
+from mds.fake.geometry import point_within, point_nearby
 from mds.schema import ProviderSchema
 import random
 import scipy.stats
@@ -29,7 +29,7 @@ class ProviderDataGenerator:
 
     def __init__(self, **kwargs):
         """
-        Initialize a new DataGenerator using the provided context. 
+        Initialize a new DataGenerator using the provided context.
 
         Required keyword arguments:
             - :boundary: is the geographic boundary within which to generate data
@@ -90,7 +90,7 @@ class ProviderDataGenerator:
 
     def service_day(self, devices, date, hour_open, hour_closed, inactivity):
         """
-        Create status change events and trips on :date: between the hours of 
+        Create status change events and trips on :date: between the hours of
         :houropen: and :hourclosed: for the given :devices:.
 
         :inactivity: the percent of devices to mark as inactive for the day
@@ -258,7 +258,7 @@ class ProviderDataGenerator:
             # reset the battery for electric devices
             if self.has_battery(device):
                 self.recharge_battery(device)
-            
+
             # combine with device details and append
             service_changes.append({**device, **service_start})
 
@@ -309,9 +309,9 @@ class ProviderDataGenerator:
         :event_time: is the time the trip should start
 
         :event_location: is the location (Feature) the trip should start
-        
+
         :end_location: is the location (Feature) the trip should end
-        
+
         :reference_time: is the 0-point around which to calculate a random start time
             - :min_td: the minimum time from :reference_time:
             - :max_td: the maximum time from :reference_time:
@@ -358,7 +358,7 @@ class ProviderDataGenerator:
         end_time = event_time + timedelta(seconds=trip_duration)
         if end_location is None:
             start_point = extract_point(event_location)
-            end_point = point_nearby_within(start_point, trip_distance, self.boundary)
+            end_point = point_nearby(start_point, trip_distance, boundary=self.boundary)
             end_location = to_feature(end_point, properties=dict(timestamp=end_time))
 
         # generate the route object


### PR DESCRIPTION
As things stand now the fake data generator starts off by placing its simulated vehicles at points inside the provided boundary file; it then simulates them taking trips by letting them roam some distance from their current location.

The problem with that approach is that vehicles can end up traveling quite far from their starting locations: in particular, when overlaid with the boundary of the city of Santa Monica, for instance, there's nothing stopping bikes and scooters from ending up scattered across the ocean. That is rather unrealistic, so this PR attempts to fix that by requiring that the end point of every trip, like its start, stay within the boundary while attempting to keep the distance distribution minimally changed.