### PR TITLE
Add optional padding to requests to reduce 

### DIFF
--- a/mds/api/client.py
+++ b/mds/api/client.py
@@ -51,7 +51,7 @@ class ProviderClient(OAuthClientCredentialsAuth):
 
         return url
 
-    def _request(self, providers, endpoint, params, paging, padding_seconds):
+    def _request(self, providers, endpoint, params, paging, rate_limit):
         """
         Internal helper for sending requests.
 
@@ -123,8 +123,8 @@ class ProviderClient(OAuthClientCredentialsAuth):
                     results[provider].append(this_page)
                     next_url = __next_url(this_page)
 
-                    if next_url and padding_seconds:
-                        time.sleep(padding_seconds)
+                    if next_url and rate_limit:
+                        time.sleep(rate_limit)
                 else:
                     break
 
@@ -143,7 +143,7 @@ class ProviderClient(OAuthClientCredentialsAuth):
         end_time=None,
         bbox=None,
         paging=True,
-        padding_seconds=0,
+        rate_limit=0,
         **kwargs):
         """
         Request Status Changes data. Returns a dict of provider => list of status_changes payload(s)
@@ -170,8 +170,7 @@ class ProviderClient(OAuthClientCredentialsAuth):
             - `paging`: True (default) to follow paging and request all available data.
                         False to request only the first page.
 
-            - `padding_seconds`: 0 (default) delay to insert between requests
-                        to limit load on providers.
+            - `rate_limit`: Number of seconds of delay to insert between paging requests.
         """
         if providers is None:
             providers = self.providers
@@ -189,7 +188,7 @@ class ProviderClient(OAuthClientCredentialsAuth):
         }
 
         # make the request(s)
-        status_changes = self._request(providers, mds.STATUS_CHANGES, params, paging, padding_seconds)
+        status_changes = self._request(providers, mds.STATUS_CHANGES, params, paging, rate_limit)
 
         return status_changes
 
@@ -202,7 +201,7 @@ class ProviderClient(OAuthClientCredentialsAuth):
         end_time=None,
         bbox=None,
         paging=True,
-        padding_seconds=0,
+        rate_limit=0,
         **kwargs):
         """
         Request Trips data. Returns a dict of provider => list of trips payload(s).
@@ -233,8 +232,7 @@ class ProviderClient(OAuthClientCredentialsAuth):
             - `paging`: True (default) to follow paging and request all available data.
                         False to request only the first page.
 
-            - `padding_seconds`: 0 (default) delay to insert between requests
-                        to limit load on providers.
+            - `rate_limit`: Number of seconds of delay to insert between paging requests.
         """
         if providers is None:
             providers = self.providers
@@ -252,6 +250,6 @@ class ProviderClient(OAuthClientCredentialsAuth):
         }
 
         # make the request(s)
-        trips = self._request(providers, mds.TRIPS, params, paging, padding_seconds)
+        trips = self._request(providers, mds.TRIPS, params, paging, rate_limit)
 
         return trips


### PR DESCRIPTION
**Issue**
When backfilling over large time volumes, a series of rapid fire requests may cause stability issues for some providers (depending on their implementation).

**Proposal**
Add an optional field of `padding_seconds` that supports adding spacing between requests. This will allow providers to implement rate limits in their systems, and prevent clients from hitting those rate limits.