### PR TITLE
Add the ability to set a specific provider UUID in the fake data generator

### DIFF
--- a/mds/fake/provider.py
+++ b/mds/fake/provider.py
@@ -65,16 +65,16 @@ class ProviderDataGenerator:
         else:
             self.propulsion_types = schema.propulsion_types()
 
-    def devices(self, N, provider):
+    def devices(self, N, provider_name, provider_id=None):
         """
         Create a list of length :N: representing devices operated by :provider:.
         """
         devices = []
-        provider_id = uuid.uuid4()
+        provider_id = provider_id or uuid.uuid4()
 
         for _ in range(N):
             device = dict(provider_id=provider_id,
-                          provider_name=provider,
+                          provider_name=provider_name,
                           device_id=uuid.uuid4(),
                           vehicle_id=random_string(6),
                           vehicle_type=random.choice(self.vehicle_types),


### PR DESCRIPTION
It's currently possible to set a custom provider name but not a custom provider id, and that feels like a gap that's pretty easy to fix.