### PR TITLE
remove incorrect break condition in paging

### DIFF
--- a/mds/api/client.py
+++ b/mds/api/client.py
@@ -121,7 +121,11 @@ class ProviderClient(OAuthClientCredentialsAuth):
 
                 if __has_data(this_page):
                     results[provider].append(this_page)
+            
                 next_url = __next_url(this_page)
+
+                if next_url and rate_limit:
+                    time.sleep(rate_limit)
 
         return results
 

--- a/mds/api/client.py
+++ b/mds/api/client.py
@@ -121,12 +121,7 @@ class ProviderClient(OAuthClientCredentialsAuth):
 
                 if __has_data(this_page):
                     results[provider].append(this_page)
-                    next_url = __next_url(this_page)
-
-                    if next_url and rate_limit:
-                        time.sleep(rate_limit)
-                else:
-                    break
+                next_url = __next_url(this_page)
 
         return results
 


### PR DESCRIPTION
we should not be breaking the paging loop when we have a page that has no data.

it's possible for a MDS provider to paginate their data at small time windows. for example, and this can be discovered by looking at the next_url, bird's api paginates for every 2 minutes.

it's possible that if i'm requesting the past hour of data, then the time window of 8-10 minutes is empty (ie. no status_changes occured in that time window), but the rest of the time windows have data.

the current code will then only ingest time windows 0-2 minutes, 2-4  minutes, 4-6  minutes, 6-8  minutes, and not ingest any of 10-12  minutes, 12-14  minutes, ..., 58-60  minutes because the while loop will break prematurely. 