### PR TITLE
fix read_data_file to handle lists of payloads

### DIFF
--- a/mds/json.py
+++ b/mds/json.py
@@ -80,6 +80,10 @@ def read_data_file(src, record_type):
         data = []
         for page in payload:
             data.extend(page["data"][record_type])
+        
+        if not all(page["version"] == payload[0]["version"] for page in payload):
+            raise("Data file has different versions across its pages. All pages need to be the same version.")
+        
         version = payload[0]["version"]
     else:
         data = payload["data"][record_type]

--- a/mds/json.py
+++ b/mds/json.py
@@ -76,8 +76,14 @@ def read_data_file(src, record_type):
     else:
         payload = json.load(open(src, "r"))
 
-    data = payload["data"][record_type]
-    return payload["version"], pd.DataFrame.from_records(data)
+    if isinstance(payload, list):
+        data = []
+        for page in payload:
+            data.extend(page["data"][record_type])
+    else:
+        data = payload["data"][record_type]
+
+    return payload[0]["version"], pd.DataFrame.from_records(data)
 
 
 class CustomJsonEncoder(json.JSONEncoder):

--- a/mds/json.py
+++ b/mds/json.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import fiona
 import json
 import os
-import pandas
+import pandas as pd
 from pathlib import Path
 import requests
 import shapely.geometry
@@ -78,13 +78,13 @@ def read_data_file(src, record_type):
 
     if isinstance(payload, list):
         data = []
-        for page in payload:
-            data.extend(page["data"][record_type])
-        
-        if not all(page["version"] == payload[0]["version"] for page in payload):
-            raise("Data file has different versions across its pages. All pages need to be the same version.")
-        
         version = payload[0]["version"]
+
+        for page in payload:
+            if page["version"] == version:
+                data.extend(page["data"][record_type])
+            else:
+                raise ValueError("Version mismatch detected.")
     else:
         data = payload["data"][record_type]
         version = payload["version"]

--- a/mds/json.py
+++ b/mds/json.py
@@ -80,10 +80,12 @@ def read_data_file(src, record_type):
         data = []
         for page in payload:
             data.extend(page["data"][record_type])
+        version = payload[0]["version"]
     else:
         data = payload["data"][record_type]
+        version = payload["version"]
 
-    return payload[0]["version"], pd.DataFrame.from_records(data)
+    return version, pd.DataFrame.from_records(data)
 
 
 class CustomJsonEncoder(json.JSONEncoder):


### PR DESCRIPTION
if we specify a file path containing a list of payloads, which is how the ingest script outputs, then the library doesn't handle the case that the file may be a list of payloads